### PR TITLE
Correct network interface names to eth1 and eth2 to reflect changes to "bento/oracle-7.5" box configuration.

### DIFF
--- a/rac/node1/scripts/oracle_grid_software_installation.sh
+++ b/rac/node1/scripts/oracle_grid_software_installation.sh
@@ -20,7 +20,7 @@ ${GRID_HOME}/gridSetup.sh -ignorePrereq -waitforcompletion -silent \
         oracle.install.crs.config.gpnp.configureGNS=false \
         oracle.install.crs.config.autoConfigureClusterNodeVIP=false \
         oracle.install.crs.config.clusterNodes=${NODE1_FQ_HOSTNAME}:${NODE1_FQ_VIPNAME}:HUB,${NODE2_FQ_HOSTNAME}:${NODE2_FQ_VIPNAME}:HUB \
-        oracle.install.crs.config.networkInterfaceList=enp0s8:${PUBLIC_SUBNET}:1,enp0s9:${PRIVATE_SUBNET}:5 \
+        oracle.install.crs.config.networkInterfaceList=eth1:${PUBLIC_SUBNET}:1,eth2:${PRIVATE_SUBNET}:5 \
         oracle.install.asm.configureGIMRDataDG=false \
         oracle.install.crs.config.useIPMI=false \
         oracle.install.asm.storageOption=ASM \


### PR DESCRIPTION
Instead of enp0s8 and enp0s9, we should have it eth1 and eth2