### PR TITLE
Remove duplicate KEYSTORE_PASSWORD entry.

### DIFF
--- a/database/ol8_19/config/install.env
+++ b/database/ol8_19/config/install.env
@@ -57,6 +57,5 @@ export APEX_REST_PASSWORD="ApexPassword1"
 export PUBLIC_PASSWORD="ApexPassword1"
 export SYS_PASSWORD="SysPassword1"
 export KEYSTORE_PASSWORD="KeystorePassword1"
-export KEYSTORE_PASSWORD="Ajp"
 export AJP_SECRET="AJPSecret1"
 export AJP_ADDRESS="::1"                                                          \


### PR DESCRIPTION
Duplicate entry caused "keytool error: java.lang.Exception: Key password must be at least 6 characters" error.