### PR TITLE
Update install_os_packages.sh, added openssh-server

### DIFF
--- a/em/ol9_em241/scripts/install_os_packages.sh
+++ b/em/ol9_em241/scripts/install_os_packages.sh
@@ -23,6 +23,7 @@ dnf install -y motif-devel
 dnf install -y redhat-lsb
 dnf install -y redhat-lsb-core
 dnf install -y openssl
+dnf install -y openssh-server
 dnf install -y make
 
 dnf install -y https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64/getPackage/compat-libpthread-nonshared-2.28-72.0.1.el8_1.1.x86_64.rpm


### PR DESCRIPTION
**SSH became unavailable after the package upgrades.** 
sshd was reporting an error with openssl version mismatch (openssl was newer).  Updating openssh-server along with openssl fixed it.