### PR TITLE
Adding the scan script to the main node2 root setup

### DIFF
--- a/rac/ol9_26/node2/scripts/root_setup.sh
+++ b/rac/ol9_26/node2/scripts/root_setup.sh
@@ -19,6 +19,7 @@ chmod -R 775 /u01
 usermod -aG vagrant oracle
 
 sh /vagrant_scripts/configure_hosts_base.sh
+sh /vagrant_scripts/configure_hosts_scan.sh
 
 cat > /etc/resolv.conf <<EOF
 search localdomain


### PR DESCRIPTION
Adding the configure_hosts_scan.sh script to include the scan in the /etc/oratab file entry.